### PR TITLE
license: Add preamble to non-eBPF C/include files

### DIFF
--- a/interpreter/php/decode_amd64.c
+++ b/interpreter/php/decode_amd64.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Apache License 2.0.
+ * See the file "LICENSE" for details.
+ */
+
 //go:build amd64
 #include <Zydis/Zydis.h>
 #include "decode_amd64.h"

--- a/interpreter/php/decode_amd64.h
+++ b/interpreter/php/decode_amd64.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Apache License 2.0.
+ * See the file "LICENSE" for details.
+ */
+
 //go:build amd64
 #ifndef __INCLUDED_PHP_DECODE_X86_64__
 #define __INCLUDED_PHP_DECODE_X86_64__

--- a/interpreter/python/decode_amd64.c
+++ b/interpreter/python/decode_amd64.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Apache License 2.0.
+ * See the file "LICENSE" for details.
+ */
+
 //go:build amd64
 
 #include <Zydis/Zydis.h>

--- a/interpreter/python/decode_amd64.h
+++ b/interpreter/python/decode_amd64.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Apache License 2.0.
+ * See the file "LICENSE" for details.
+ */
+
 //go:build amd64
 
 #ifndef __PYTHON_DECODE_X86_64__

--- a/libpf/pfelf/testdata/fixed-address.c
+++ b/libpf/pfelf/testdata/fixed-address.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Apache License 2.0.
+ * See the file "LICENSE" for details.
+ */
+
 __attribute__((section(".coffee_section")))
 int function_at_fixed_address(void) {
     return 0;

--- a/libpf/pfelf/testdata/test.c
+++ b/libpf/pfelf/testdata/test.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Apache License 2.0.
+ * See the file "LICENSE" for details.
+ */
+
 #ifndef LINUX_VERSION
 #define LINUX_VERSION ""
 #endif

--- a/reporter/testdata/test.c
+++ b/reporter/testdata/test.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Apache License 2.0.
+ * See the file "LICENSE" for details.
+ */
+
 #include <unistd.h>
 
 int main(int argc, char *argv[]) {

--- a/tpbase/fsbase_decode_amd64.c
+++ b/tpbase/fsbase_decode_amd64.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Apache License 2.0.
+ * See the file "LICENSE" for details.
+ */
+
 //go:build amd64
 
 #include <Zydis/Zydis.h>

--- a/tpbase/fsbase_decode_amd64.h
+++ b/tpbase/fsbase_decode_amd64.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Apache License 2.0.
+ * See the file "LICENSE" for details.
+ */
+
 //go:build amd64
 
 #ifndef __FSBASE_DECODE_X86_64__

--- a/tpbase/libc_decode_amd64.c
+++ b/tpbase/libc_decode_amd64.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Apache License 2.0.
+ * See the file "LICENSE" for details.
+ */
+
 //go:build amd64
 
 #include <Zydis/Zydis.h>

--- a/tpbase/libc_decode_amd64.h
+++ b/tpbase/libc_decode_amd64.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Apache License 2.0.
+ * See the file "LICENSE" for details.
+ */
+
 //go:build amd64
 
 #ifndef LIBC_DECODE_X86_64

--- a/utils/coredump/testsources/c/brokenstack.c
+++ b/utils/coredump/testsources/c/brokenstack.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Apache License 2.0.
+ * See the file "LICENSE" for details.
+ */
+
 // Example application that intentionally breaks its stack.
 // 
 // cc -O2 -g -o brokenstack brokenstack.c

--- a/utils/coredump/testsources/c/sig.c
+++ b/utils/coredump/testsources/c/sig.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Apache License 2.0.
+ * See the file "LICENSE" for details.
+ */
+
 #include<stdio.h>
 #include<signal.h>
 #include<unistd.h>

--- a/utils/coredump/testsources/c/stackalign.c
+++ b/utils/coredump/testsources/c/stackalign.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Apache License 2.0.
+ * See the file "LICENSE" for details.
+ */
+
 // gcc -O3 -fomit-frame-pointer -mavx -ftree-vectorize stackalign.c -o stackalign
 
 #include <unistd.h>


### PR DESCRIPTION
To clarify for readers: The eBPF C code in this repository is GPL licensed (and not affected by this PR). We have additional non-eBPF code however, and that is licensed under Apache2.