### PR TITLE
Run build container as user

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.cache
+go

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.o
 *.pb.go
-.idea
+.cache
+/.idea
+/go
 otel-profiling-agent
 tracer.ebpf
 tracer.ebpf.arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,12 @@ RUN                                                                             
     && find "$INSTALL_DIR/include" -type f -exec chmod +r {} \;                    \
     && rm "$PB_FILE"
 
+# The docker image is built as root - make binaries available to user.
+RUN mv /root/go/bin/* /usr/local/bin/
+
+ENV GOPATH=/agent/go
+ENV GOCACHE=/agent/.cache
+
 RUN echo "export PATH=\"\$PATH:\$(go env GOPATH)/bin\"" >> ~/.bashrc
 
 ENTRYPOINT ["/bin/bash", "-l", "-c"]

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ docker-image:
 	docker build -t profiling-agent --build-arg arch=$(NATIVE_ARCH) -f Dockerfile .
 
 agent:
-	docker run -v "$$PWD":/agent -it --user $(shell id -u):$(shell id -g) profiling-agent make
+	docker run -v "$$PWD":/agent -it --rm --user $(shell id -u):$(shell id -g) profiling-agent make
 
 legal:
 	@go install go.elastic.co/go-licence-detector@latest

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,11 @@ all: generate ebpf binary
 
 # Removes the go build cache and binaries in the current project
 clean:
-	go clean -cache -i
-	$(MAKE) -C support/ebpf clean
-	rm -f build-targets/*.{deb,rpm}
-	rm -f support/*.test
+	@go clean -cache -i
+	@$(MAKE) -s -C support/ebpf clean
+	@rm -f support/*.test
+	@chmod -Rf u+w go/ || true
+	@rm -rf go .cache
 
 generate: protobuf
 	go install github.com/florianl/bluebox@v0.0.1
@@ -57,7 +58,7 @@ docker-image:
 	docker build -t profiling-agent --build-arg arch=$(NATIVE_ARCH) -f Dockerfile .
 
 agent:
-	docker run -v "$$PWD":/agent -it profiling-agent make
+	docker run -v "$$PWD":/agent -it --user $(shell id -u):$(shell id -g) profiling-agent make
 
 legal:
 	@go install go.elastic.co/go-licence-detector@latest


### PR DESCRIPTION
Running the build container as root (default) creates temporary files owning root outside the container. A `make clean` will run into permission denied.