### PR TITLE
Add build and version info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,17 @@
 .PHONY: all all-common binary clean ebpf generate test test-deps protobuf docker-image agent legal
 
-SHELL:=/usr/bin/env bash
+SHELL := /usr/bin/env bash
+
+BRANCH = $(shell git rev-parse --abbrev-ref HEAD | tr -d '-' | tr '[:upper:]' '[:lower:]')
+COMMIT_SHORT_SHA = $(shell git rev-parse --short=8 HEAD)
+
+VERSION ?= v0.0.0
+BUILD_TIMESTAMP ?= $(shell date +%s)
+REVISION ?= $(BRANCH)-$(COMMIT_SHORT_SHA)
+
+VC_LDFLAGS := -X github.com/elastic/otel-profiling-agent/vc.version=$(VERSION) \
+	-X github.com/elastic/otel-profiling-agent/vc.revision=$(REVISION) \
+	-X github.com/elastic/otel-profiling-agent/vc.buildTimestamp=$(BUILD_TIMESTAMP)
 
 all: generate ebpf binary
 
@@ -17,7 +28,7 @@ generate:
 	go generate ./...
 
 binary:
-	go build -buildvcs=false -ldflags="-extldflags=-static" -tags osusergo,netgo
+	go build -buildvcs=false -ldflags="$(VC_LDFLAGS) -extldflags=-static" -tags osusergo,netgo
 
 ebpf:
 	$(MAKE) -j$(shell nproc) -C support/ebpf
@@ -55,7 +66,8 @@ docker-image:
 	docker build -t profiling-agent --build-arg arch=$(NATIVE_ARCH) -f Dockerfile .
 
 agent:
-	docker run -v "$$PWD":/agent -it --rm --user $(shell id -u):$(shell id -g) profiling-agent make
+	docker run -v "$$PWD":/agent -it --rm --user $(shell id -u):$(shell id -g) profiling-agent \
+		make VERSION=$(VERSION) REVISION=$(REVISION) BUILD_TIMESTAMP=$(BUILD_TIMESTAMP)
 
 legal:
 	@go install go.elastic.co/go-licence-detector@latest

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/elastic/otel-profiling-agent/containermetadata"
+	"github.com/elastic/otel-profiling-agent/vc"
 	"golang.org/x/sys/unix"
 
 	"github.com/elastic/otel-profiling-agent/host"
@@ -58,8 +59,6 @@ https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
 type exitCode int
 
 const (
-	version string = "0.1.0"
-
 	exitSuccess exitCode = 0
 	exitFailure exitCode = 1
 
@@ -109,7 +108,7 @@ func mainWithExitCode() exitCode {
 	}
 
 	if argVersion {
-		fmt.Printf("%s\n", version)
+		fmt.Printf("%s\n", vc.Version())
 		return exitSuccess
 	}
 
@@ -143,7 +142,8 @@ func mainWithExitCode() exitCode {
 	}
 
 	startTime := time.Now()
-	log.Infof("Starting OTEL profiling agent")
+	log.Infof("Starting OTEL profiling agent %s (revision %s, build timestamp %s)",
+		vc.Version(), vc.Revision(), vc.BuildTimestamp())
 
 	// Enable dumping of full heaps if the size of the allocated Golang heap
 	// exceeds 150m, and start dumping memory profiles when the heap exceeds
@@ -219,6 +219,9 @@ func mainWithExitCode() exitCode {
 
 	log.Debugf("Reading the configuration")
 	conf := config.Config{
+		Version:                vc.Version(),
+		Revision:               vc.Revision(),
+		BuildTimestamp:         vc.BuildTimestamp(),
 		ProjectID:              uint32(argProjectID),
 		CacheDirectory:         argCacheDirectory,
 		EnvironmentType:        argEnvironmentType,

--- a/vc/vc.go
+++ b/vc/vc.go
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Apache License 2.0.
+ * See the file "LICENSE" for details.
+ */
+
+// Package vc provides buildtime information.
+package vc
+
+var (
+	// The following variables are going to be set at link time using ldflags
+	// and can be referenced later in the program.
+
+	// revision of the service
+	revision = ""
+	// buildTimestamp, timestamp of the build
+	buildTimestamp = ""
+	// version in vX.Y.Z{-N-abbrev} format (via git-describe --tags)
+	version = ""
+)
+
+// Revision of the service.
+func Revision() string {
+	return revision
+}
+
+// BuildTimestamp returns the timestamp of the build.
+func BuildTimestamp() string {
+	return buildTimestamp
+}
+
+// Version in vX.Y.Z{-N-abbrev} format.
+func Version() string {
+	return version
+}


### PR DESCRIPTION
This PR adds code to plumb agent version, revision and build times through the Makefile and initializes the previously default-initialized `Config` fields with proper values. It effectively mirrors what we are also doing in the Elastic distribution of the agent.