### PR TITLE
Properly populate reported mappings with ELF VAs

### DIFF
--- a/libpf/trace.go
+++ b/libpf/trace.go
@@ -19,7 +19,7 @@ type Trace struct {
 	Hash               TraceHash
 }
 
-// AppendFrame appends a frame to the columnar frame array.
+// AppendFrame appends a frame to the columnar frame array without mapping information.
 func (trace *Trace) AppendFrame(ty FrameType, file FileID, addrOrLine AddressOrLineno) {
 	trace.AppendFrameFull(ty, file, addrOrLine, 0, 0, 0)
 }

--- a/libpf/trace.go
+++ b/libpf/trace.go
@@ -10,15 +10,27 @@ package libpf
 // stack frame via the file ID and line number at the offset i in the trace. The
 // information for the most recently called function is at offset 0.
 type Trace struct {
-	Files      []FileID
-	Linenos    []AddressOrLineno
-	FrameTypes []FrameType
-	Hash       TraceHash
+	Files              []FileID
+	Linenos            []AddressOrLineno
+	FrameTypes         []FrameType
+	MappingStart       []Address
+	MappingEnd         []Address
+	MappingFileOffsets []uint64
+	Hash               TraceHash
 }
 
 // AppendFrame appends a frame to the columnar frame array.
 func (trace *Trace) AppendFrame(ty FrameType, file FileID, addrOrLine AddressOrLineno) {
+	trace.AppendFrameFull(ty, file, addrOrLine, 0, 0, 0)
+}
+
+// AppendFrameFull appends a frame with mapping info to the columnar frame array.
+func (trace *Trace) AppendFrameFull(ty FrameType, file FileID, addrOrLine AddressOrLineno,
+	mappingStart Address, mappingEnd Address, mappingFileOffset uint64) {
 	trace.FrameTypes = append(trace.FrameTypes, ty)
 	trace.Files = append(trace.Files, file)
 	trace.Linenos = append(trace.Linenos, addrOrLine)
+	trace.MappingStart = append(trace.MappingStart, mappingStart)
+	trace.MappingEnd = append(trace.MappingEnd, mappingEnd)
+	trace.MappingFileOffsets = append(trace.MappingFileOffsets, mappingFileOffset)
 }

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -259,7 +259,7 @@ func (pm *ProcessManager) ConvertTrace(trace *host.Trace) (newTrace *libpf.Trace
 			// Locate mapping info for the frame.
 			var mappingStart, mappingEnd libpf.Address
 			var fileOffset uint64
-			if frame.Type.Interpreter() != libpf.Kernel {
+			if frame.Type.Interpreter() == libpf.Native {
 				if mapping, ok := pm.findMappingForTrace(trace.PID, frame.File, frame.Lineno); ok {
 					mappingStart = mapping.Vaddr - libpf.Address(mapping.Bias)
 					mappingEnd = mappingStart + libpf.Address(mapping.Length)

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -237,54 +237,49 @@ func (pm *ProcessManager) ConvertTrace(trace *host.Trace) (newTrace *libpf.Trace
 			log.Errorf("Unexpected frame type 0x%02X (neither error nor interpreter frame)",
 				uint8(frame.Type))
 		case libpf.Native, libpf.Kernel:
-			// When unwinding stacks, the address is obtained from the stack
-			// which contains pointer to the *next* instruction to be executed.
+			// The BPF code classifies whether an address is a return address or not.
+			// Return addresses are where execution resumes when returning to the stack
+			// frame and point to the **next instruction** after the call instruction
+			// that produced the frame.
 			//
-			// For all kernel frames, the kernel unwinder will always produce
-			// a frame in which the RIP is after a call instruction (it hides the top
-			// frames that leads to the unwinder itself).
+			// For these return addresses we subtract 1 from the address in order to
+			// make it point into the call that precedes it: the instruction at the
+			// return address may already be part of whatever code follows after the
+			// call, and we want the return addresses to resolve to the call itself
+			// during symbolization.
 			//
-			// For leaf user mode frames (without kernel frames) the RIP from
-			// our unwinder is good as is, and must not be altered because the
-			// previous instruction address is unknown -- we might have just
-			// executed a jump or a call that got us to the address found in
-			// these frames.
-			//
-			// For other user mode frames we are at the next instruction after a
-			// call. And often the next instruction is already part of the next
-			// source code line's debug info areas. So we need to fixup the non-top
-			// frames so that we get source code lines pointing to the call instruction.
-			// We would ideally wish to subtract the size of the instruction from
-			// the return address we retrieved - but the size of calls can vary
-			// (indirect calls etc.). If, on the other hand, we subtract 1 from
-			// the address, we ensure that we fall into the range of addresses
-			// associated with that function call in the debug information.
-			//
-			// The unwinder will produce stack traces like the following:
-			//
-			// Frame 0:
-			// bla %reg           <- address of frame 0
-			// retq
-			//
-			// Frame 1:
-			// call <function>
-			// add %rax, %rbx     <- address of frame 1 == return address of frame 0
-
+			// Optimally we'd subtract the size of the call instruction here instead
+			// of doing `- 1`, but disassembling backwards is quite difficult for
+			// variable length instruction sets like X86.
 			relativeRIP := frame.Lineno
 			if frame.ReturnAddress {
 				relativeRIP--
 			}
+
+			// Locate mapping info for the frame.
+			var mappingStart, mappingEnd libpf.Address
+			var fileOffset uint64
+			if frame.Type.Interpreter() != libpf.Kernel {
+				if mapping, ok := pm.findMappingForTrace(trace.PID, frame.File, frame.Lineno); ok {
+					mappingStart = mapping.Vaddr - libpf.Address(mapping.Bias)
+					mappingEnd = mappingStart + libpf.Address(mapping.Length)
+					fileOffset = mapping.FileOffset
+				}
+			}
+
 			fileID, ok := pm.FileIDMapper.Get(frame.File)
 			if !ok {
 				log.Debugf(
 					"file ID lookup failed for PID %d, frame %d/%d, frame type %d",
 					trace.PID, i, traceLen, frame.Type)
 
-				newTrace.AppendFrame(frame.Type, libpf.UnsymbolizedFileID,
-					libpf.AddressOrLineno(0))
+				newTrace.AppendFrameFull(frame.Type, libpf.UnsymbolizedFileID,
+					libpf.AddressOrLineno(0), mappingStart, mappingEnd, fileOffset)
 				continue
 			}
-			newTrace.AppendFrame(frame.Type, fileID, relativeRIP)
+
+			newTrace.AppendFrameFull(frame.Type, fileID,
+				relativeRIP, mappingStart, mappingEnd, fileOffset)
 		default:
 			err := pm.symbolizeFrame(i, trace, newTrace)
 			if err != nil {
@@ -298,6 +293,33 @@ func (pm *ProcessManager) ConvertTrace(trace *host.Trace) (newTrace *libpf.Trace
 	}
 	newTrace.Hash = traceutil.HashTrace(newTrace)
 	return newTrace
+}
+
+// findMappingForTrace locates the mapping for a given host trace.
+func (pm *ProcessManager) findMappingForTrace(pid util.PID, fid host.FileID,
+	addr libpf.AddressOrLineno) (m Mapping, found bool) {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	procInfo, ok := pm.pidToProcessInfo[pid]
+	if !ok {
+		return Mapping{}, false
+	}
+
+	fidMappings, ok := procInfo.mappingsByFileID[fid]
+	if !ok {
+		return Mapping{}, false
+	}
+
+	for _, candidate := range fidMappings {
+		procSpaceVA := libpf.Address(uint64(addr) + candidate.Bias)
+		mappingEnd := candidate.Vaddr + libpf.Address(candidate.Length)
+		if procSpaceVA >= candidate.Vaddr && procSpaceVA <= mappingEnd {
+			return *candidate, true
+		}
+	}
+
+	return Mapping{}, false
 }
 
 func (pm *ProcessManager) MaybeNotifyAPMAgent(

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -86,8 +86,9 @@ func (pm *ProcessManager) updatePidInformation(pid util.PID, m *Mapping) (bool, 
 		// We don't have information for this pid, so we first need to
 		// allocate the embedded map for this process.
 		info = &processInfo{
-			mappings: make(map[libpf.Address]Mapping),
-			tsdInfo:  nil,
+			mappings:         make(map[libpf.Address]*Mapping),
+			mappingsByFileID: make(map[host.FileID]map[libpf.Address]*Mapping),
+			tsdInfo:          nil,
 		}
 		pm.pidToProcessInfo[pid] = info
 
@@ -100,13 +101,13 @@ func (pm *ProcessManager) updatePidInformation(pid util.PID, m *Mapping) (bool, 
 		}
 		pm.pidPageToMappingInfoSize++
 	} else if mf, ok := info.mappings[m.Vaddr]; ok {
-		if *m == mf {
+		if *m == *mf {
 			// We try to update our information about a particular mapping we already know about.
 			return true, nil
 		}
 	}
 
-	info.mappings[m.Vaddr] = *m
+	info.addMapping(*m)
 
 	prefixes, err := lpm.CalculatePrefixList(uint64(m.Vaddr), uint64(m.Vaddr)+m.Length)
 	if err != nil {
@@ -155,7 +156,7 @@ func (pm *ProcessManager) deletePIDAddress(pid util.PID, addr libpf.Address) err
 	}
 
 	pm.pidPageToMappingInfoSize -= uint64(deleted)
-	delete(info.mappings, addr)
+	info.removeMapping(mapping)
 
 	return pm.eim.RemoveOrDecRef(mapping.FileID)
 }

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -661,9 +661,13 @@ func (t *Tracer) insertKernelFrames(trace *host.Trace, ustackLen uint32,
 		t.processManager.FileIDMapper.Set(hostFileID, fileID)
 
 		trace.Frames[i] = host.Frame{
-			File:          hostFileID,
-			Lineno:        libpf.AddressOrLineno(addr),
-			Type:          libpf.KernelFrame,
+			File:   hostFileID,
+			Lineno: libpf.AddressOrLineno(addr),
+			Type:   libpf.KernelFrame,
+
+			// For all kernel frames, the kernel unwinder will always produce a
+			// frame in which the RIP is after a call instruction (it hides the
+			// top frames that leads to the unwinder itself).
 			ReturnAddress: true,
 		}
 


### PR DESCRIPTION
This reworks `ProcessManager` and the OTLP reporter to send out memory mappings in **ELF address space** as explained [here](https://github.com/open-telemetry/opentelemetry-proto/pull/553#issuecomment-2163412417).

CC @brancz