### PR TITLE
Extend reporter interface to support symbol upload

### DIFF
--- a/interpreter/dotnet/instance.go
+++ b/interpreter/dotnet/instance.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
+	"os"
 	"path"
 	"slices"
 	"strings"
@@ -630,8 +631,11 @@ func (i *dotnetInstance) SynchronizeMappings(ebpf interpreter.EbpfHandler,
 			info.simpleName, info.guid)
 
 		if !info.reported {
-			symbolReporter.ExecutableMetadata(context.TODO(),
-				info.fileID, path.Base(m.Path), info.guid)
+			open := func() (process.ReadAtCloser, error) {
+				return os.Open(m.Path)
+			}
+			symbolReporter.ExecutableMetadata(context.TODO(), info.fileID, path.Base(m.Path),
+				info.guid, libpf.Dotnet, open)
 			info.reported = true
 		}
 

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -258,7 +258,8 @@ type symbolReporterMockup struct{}
 
 func (s *symbolReporterMockup) ReportFallbackSymbol(_ libpf.FrameID, _ string) {}
 
-func (s *symbolReporterMockup) ExecutableMetadata(_ context.Context, _ libpf.FileID, _, _ string) {
+func (s *symbolReporterMockup) ExecutableMetadata(_ context.Context, _ libpf.FileID, _, _ string,
+	_ libpf.InterpreterType, _ reporter.ExecutableOpener) {
 }
 
 func (s *symbolReporterMockup) FrameMetadata(_ libpf.FileID, _ libpf.AddressOrLineno,

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -300,7 +300,11 @@ func (pm *ProcessManager) getELFInfo(pr process.Process, mapping *process.Mappin
 	}
 
 	buildID, _ := ef.GetBuildID()
-	pm.reporter.ExecutableMetadata(context.TODO(), fileID, baseName, buildID)
+	mapping2 := *mapping // copy to avoid races if callee saves the closure
+	open := func() (process.ReadAtCloser, error) {
+		return pr.OpenMappingFile(&mapping2)
+	}
+	pm.reporter.ExecutableMetadata(context.TODO(), fileID, baseName, buildID, libpf.Native, open)
 
 	return info
 }

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -160,8 +160,8 @@ func (r *OTLPReporter) ReportFallbackSymbol(frameID libpf.FrameID, symbol string
 
 // ExecutableMetadata accepts a fileID with the corresponding filename
 // and caches this information.
-func (r *OTLPReporter) ExecutableMetadata(_ context.Context,
-	fileID libpf.FileID, fileName, buildID string) {
+func (r *OTLPReporter) ExecutableMetadata(_ context.Context, fileID libpf.FileID, fileName,
+	buildID string, _ libpf.InterpreterType, _ ExecutableOpener) {
 	r.executables.Add(fileID, execInfo{
 		fileName: fileName,
 		buildID:  buildID,

--- a/tools/coredump/coredump.go
+++ b/tools/coredump/coredump.go
@@ -17,6 +17,7 @@ import (
 	"unsafe"
 
 	cebpf "github.com/cilium/ebpf"
+	"github.com/elastic/otel-profiling-agent/reporter"
 
 	"github.com/elastic/otel-profiling-agent/config"
 	"github.com/elastic/otel-profiling-agent/libpf"
@@ -65,7 +66,7 @@ func newSymbolizationCache() *symbolizationCache {
 }
 
 func (c *symbolizationCache) ExecutableMetadata(_ context.Context, fileID libpf.FileID,
-	fileName, _ string) {
+	fileName, _ string, _ libpf.InterpreterType, _ reporter.ExecutableOpener) {
 	c.files[fileID] = fileName
 }
 

--- a/tracer/ebpf_integration_test.go
+++ b/tracer/ebpf_integration_test.go
@@ -19,10 +19,11 @@ import (
 	cebpf "github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 
-	"github.com/elastic/otel-profiling-agent/libpf"
 	"github.com/elastic/otel-profiling-agent/config"
 	"github.com/elastic/otel-profiling-agent/host"
 	hostmeta "github.com/elastic/otel-profiling-agent/hostmetadata/host"
+	"github.com/elastic/otel-profiling-agent/libpf"
+	"github.com/elastic/otel-profiling-agent/reporter"
 	"github.com/elastic/otel-profiling-agent/rlimit"
 	"github.com/elastic/otel-profiling-agent/support"
 	"github.com/elastic/otel-profiling-agent/util"
@@ -97,8 +98,10 @@ func (f mockIntervals) PIDCleanupInterval() time.Duration { return 1 * time.Seco
 
 type mockReporter struct{}
 
-func (f mockReporter) ExecutableMetadata(_ context.Context, _ libpf.FileID, _, _ string) {}
-func (f mockReporter) ReportFallbackSymbol(_ libpf.FrameID, _ string)                    {}
+func (f mockReporter) ExecutableMetadata(_ context.Context, _ libpf.FileID, _, _ string,
+	_ libpf.InterpreterType, _ reporter.ExecutableOpener) {
+}
+func (f mockReporter) ReportFallbackSymbol(_ libpf.FrameID, _ string) {}
 func (f mockReporter) FrameMetadata(_ libpf.FileID, _ libpf.AddressOrLineno, _ util.SourceLineno,
 	_ uint32, _, _ string) {
 }

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -169,7 +169,7 @@ func processKernelModulesMetadata(ctx context.Context,
 		}
 
 		result[nameStr] = fileID
-		rep.ExecutableMetadata(ctx, fileID, nameStr, buildID)
+		rep.ExecutableMetadata(ctx, fileID, nameStr, buildID, libpf.Kernel, nil)
 	})
 
 	return result, nil


### PR DESCRIPTION
There was [some interest](https://cloud-native.slack.com/archives/C03J794L0BV/p1718379810177579) in extending the reporter interface to allow agent-as-a-libray consumers of this repository to experiment with automatic symbol upload. This PR extends `ExecutableMetadata` with two new arguments:

- The interpreter kind that the executable is being reported for. As of writing, this can be `Native`, `Kernel`, or `Dotnet`
- A callback that can be used to open the executable on disk

As far as I can tell, this should provide everything to launch an executable upload / symbol extraction in the background.