### PR TITLE
Don't send empty sample attributes

### DIFF
--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -680,6 +680,10 @@ func getSampleAttributes(profile *profiles.Profile, i traceFramesCounts) []uint6
 	indices := make([]uint64, 0, 4)
 
 	addAttr := func(k attribute.Key, v string) {
+		if v == "" {
+			return
+		}
+
 		indices = append(indices, uint64(len(profile.AttributeTable)))
 		profile.AttributeTable = append(profile.AttributeTable, &common.KeyValue{
 			Key:   string(k),


### PR DESCRIPTION
We'd previously needlessly send a bunch of empty attributes:

<img width="1612" alt="Screenshot 2024-06-27 at 14 15 10" src="https://github.com/elastic/otel-profiling-agent/assets/6553158/13af9443-aed3-4c69-86bf-060b6a70c70b">

This PR adds a check to omit those.

