### PR TITLE
New package env to reduce global vars

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,12 +18,10 @@ func TestSetConfiguration(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := Config{
-		ProjectID:       42,
-		CacheDirectory:  cwd,
-		EnvironmentType: "aws",
-		MachineID:       "0xfeeddeadbeefbeef",
-		SecretToken:     "secret",
-		ValidatedTags:   "",
+		ProjectID:      42,
+		CacheDirectory: cwd,
+		SecretToken:    "secret",
+		ValidatedTags:  "",
 	}
 
 	// Test setting environment to "aws".
@@ -31,23 +29,7 @@ func TestSetConfiguration(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg2 := cfg
-	cfg2.EnvironmentType = "bla"
+	cfg2.SecretToken = ""
 	err = SetConfiguration(&cfg2)
-	require.Error(t, err)
-
-	cfg3 := cfg
-	cfg3.MachineID = ""
-	err = SetConfiguration(&cfg3)
-	require.Error(t, err)
-
-	cfg4 := cfg
-	cfg4.EnvironmentType = ""
-	err = SetConfiguration(&cfg4)
-	require.Error(t, err)
-
-	cfg5 := cfg
-	cfg5.EnvironmentType = "aws"
-	cfg5.SecretToken = ""
-	err = SetConfiguration(&cfg5)
 	require.Error(t, err)
 }

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -1,0 +1,30 @@
+package env
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetConfiguration(t *testing.T) {
+	_, err := NewEnvironment("aws", "0xfeeddeadbeefbeef")
+	require.NoError(t, err)
+
+	_, err = NewEnvironment("bla", "0xfeeddeadbeefbeef")
+	require.Error(t, err)
+
+	_, err = NewEnvironment("bla", "")
+	require.Error(t, err)
+
+	_, err = NewEnvironment("aws", "")
+	require.Error(t, err)
+
+	var e *Environment
+	e, err = NewEnvironment("", "")
+	if err != nil {
+		require.Nil(t, e)
+	} else {
+		require.NotNil(t, e)
+		require.NotEqual(t, envUnspec, e.envType)
+	}
+}


### PR DESCRIPTION
Due to historical reasons, the code currently has a number of global variables, hidden behind types like `config.Config`.

This PR is a first step to avoid global variables by introducing the `env` package.