### PR TITLE
Rename env/ to platform/

### DIFF
--- a/hostmetadata/collector.go
+++ b/hostmetadata/collector.go
@@ -10,7 +10,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/elastic/otel-profiling-agent/env"
+	"github.com/elastic/otel-profiling-agent/platform"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/elastic/otel-profiling-agent/hostmetadata/agent"
@@ -30,11 +30,11 @@ type Collector struct {
 	customData map[string]string
 
 	// env is the environment object that provides information about the runtime environment.
-	env *env.Environment
+	env *platform.Environment
 }
 
 // NewCollector returns a new Collector for the specified collection agent endpoint.
-func NewCollector(caEndpoint string, environment *env.Environment) *Collector {
+func NewCollector(caEndpoint string, environment *platform.Environment) *Collector {
 	return &Collector{
 		caEndpoint: caEndpoint,
 		customData: make(map[string]string),

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 	_ "net/http/pprof"
 
 	"github.com/elastic/otel-profiling-agent/containermetadata"
-	"github.com/elastic/otel-profiling-agent/env"
+	"github.com/elastic/otel-profiling-agent/platform"
 	"github.com/elastic/otel-profiling-agent/vc"
 	"golang.org/x/sys/unix"
 
@@ -136,7 +136,7 @@ func mainWithExitCode() exitCode {
 	log.Infof("Starting OTEL profiling agent %s (revision %s, build timestamp %s)",
 		vc.Version(), vc.Revision(), vc.BuildTimestamp())
 
-	environment, err := env.NewEnvironment(args.environmentType, args.machineID)
+	environment, err := platform.NewEnvironment(args.environmentType, args.machineID)
 	if err != nil {
 		log.Errorf("Failed to create environment: %v", err)
 		return exitFailure

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -4,7 +4,7 @@
  * See the file "LICENSE" for details.
  */
 
-package env
+package platform
 
 import (
 	"context"

--- a/platform/platform_test.go
+++ b/platform/platform_test.go
@@ -1,4 +1,4 @@
-package env
+package platform
 
 import (
 	"testing"


### PR DESCRIPTION
`env` often refers to environment variables, but here we refer code for compute platforms.