### PR TITLE
coredump: create directory modulecache

### DIFF
--- a/tools/coredump/main.go
+++ b/tools/coredump/main.go
@@ -67,6 +67,5 @@ func initModuleStore() (*modulestore.Store, error) {
 		return nil, err
 	}
 	s3Client := s3.NewFromConfig(cfg)
-	ms := modulestore.New(s3Client, moduleStoreS3Bucket, "modulecache")
-	return ms, nil
+	return modulestore.New(s3Client, moduleStoreS3Bucket, "modulecache")
 }

--- a/tools/coredump/modulestore/store.go
+++ b/tools/coredump/modulestore/store.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path"
 	"strings"
@@ -62,12 +63,26 @@ type Store struct {
 
 // New creates a new module storage. The modules present in the local cache are inspected and a
 // full index of the modules in the remote S3 bucket is retrieved and cached as well.
-func New(s3client *s3.Client, s3Bucket, localCachePath string) *Store {
+func New(s3client *s3.Client, s3Bucket, localCachePath string) (*Store, error) {
+	fi, err := os.Stat(localCachePath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			if err = os.Mkdir(localCachePath, 0750); err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
+	} else {
+		if !fi.IsDir() {
+			return nil, fmt.Errorf("%s is not a directory", localCachePath)
+		}
+	}
 	return &Store{
 		s3client:       s3client,
 		bucket:         s3Bucket,
 		localCachePath: localCachePath,
-	}
+	}, nil
 }
 
 // InsertModuleLocally places a file into the local cache, returning an ID to refer it by in the

--- a/tools/coredump/modulestore/store.go
+++ b/tools/coredump/modulestore/store.go
@@ -14,7 +14,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"path"
 	"strings"
@@ -64,19 +63,8 @@ type Store struct {
 // New creates a new module storage. The modules present in the local cache are inspected and a
 // full index of the modules in the remote S3 bucket is retrieved and cached as well.
 func New(s3client *s3.Client, s3Bucket, localCachePath string) (*Store, error) {
-	fi, err := os.Stat(localCachePath)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			if err = os.Mkdir(localCachePath, 0750); err != nil {
-				return nil, err
-			}
-		} else {
-			return nil, err
-		}
-	} else {
-		if !fi.IsDir() {
-			return nil, fmt.Errorf("%s is not a directory", localCachePath)
-		}
+	if err := os.MkdirAll(localCachePath, 0750); err != nil {
+		return nil, err
 	}
 	return &Store{
 		s3client:       s3client,


### PR DESCRIPTION
modulecache is a hardcoded name for a directory used in the scope of coredump. If it does not exist, coredump will run into multiple errors. As modulecache is an essential part and also referenced in .gitignore, create it if it does not yet exist.