### PR TITLE
Fix kernel version check to >= 4.19

### DIFF
--- a/main.go
+++ b/main.go
@@ -368,7 +368,7 @@ func sanityCheck(args *arguments) exitCode {
 		var minMajor, minMinor uint32
 		switch runtime.GOARCH {
 		case "amd64":
-			minMajor, minMinor = 4, 15
+			minMajor, minMinor = 4, 19
 		case "arm64":
 			// Older ARM64 kernel versions have broken bpf_probe_read.
 			// https://github.com/torvalds/linux/commit/6ae08ae3dea2cfa03dd3665a3c8475c2d429ef47


### PR DESCRIPTION
Fixing the kernel version check for amd64 from >= 4.15 to >= 4.19