### PR TITLE
Hotspot tests: mock process memory reading

### DIFF
--- a/interpreter/hotspot/instance_test.go
+++ b/interpreter/hotspot/instance_test.go
@@ -7,25 +7,20 @@
 package hotspot
 
 import (
+	"bytes"
 	"encoding/binary"
-	"os"
 	"strings"
 	"testing"
-	"unsafe"
 
 	"github.com/elastic/go-freelru"
-
 	"github.com/elastic/otel-profiling-agent/libpf"
 	"github.com/elastic/otel-profiling-agent/lpm"
 	"github.com/elastic/otel-profiling-agent/remotememory"
-	"github.com/elastic/otel-profiling-agent/util"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestJavaSymbolExtraction(t *testing.T) {
-	rm := remotememory.NewProcessVirtualMemory(util.PID(os.Getpid()))
 	id := hotspotData{}
 	vmd, _ := id.GetOrInit(func() (hotspotVMData, error) {
 		vmd := hotspotVMData{}
@@ -33,6 +28,11 @@ func TestJavaSymbolExtraction(t *testing.T) {
 		vmd.vmStructs.Symbol.Body = 4
 		return vmd, nil
 	})
+
+	maxLength := 1024
+	sym := make([]byte, vmd.vmStructs.Symbol.Body+uint(maxLength))
+	rd := bytes.NewReader(sym)
+	rm := remotememory.RemoteMemory{ReaderAt: rd}
 
 	addrToSymbol, err := freelru.New[libpf.Address, string](2, libpf.Address.Hash32)
 	require.NoError(t, err, "symbol cache failed")
@@ -44,14 +44,12 @@ func TestJavaSymbolExtraction(t *testing.T) {
 		prefixes:     libpf.Set[lpm.Prefix]{},
 		stubs:        map[libpf.Address]StubRoutine{},
 	}
-	maxLength := 1024
-	sym := make([]byte, vmd.vmStructs.Symbol.Body+uint(maxLength))
+
 	str := strings.Repeat("a", maxLength)
 	copy(sym[vmd.vmStructs.Symbol.Body:], str)
 	for i := 0; i <= maxLength; i++ {
 		binary.LittleEndian.PutUint16(sym[vmd.vmStructs.Symbol.Length:], uint16(i))
-		address := libpf.Address(uintptr(unsafe.Pointer(&sym[0])))
-		got := ii.getSymbol(address)
+		got := ii.getSymbol(0)
 		assert.Equal(t, str[:i], got, "symbol length %d mismatched read", i)
 		ii.addrToSymbol.Purge()
 	}


### PR DESCRIPTION
The `TestJavaSymbolExtraction` test would previously fail when running under qemu-user: if the application is running under emulation, the pointer addresses don't actually correspond to real memory addresses, so if the applications peeks through the curtains of emulation via `process_vm_read`, it would read back the wrong values. This PR replaces the real memory read with a mocked one from an array.

(Revived version of https://github.com/elastic/otel-profiling-agent/pull/73 that got auto-closed due to #76)