### PR TITLE
v8: fix mappings synchronization

### DIFF
--- a/interpreter/nodev8/v8.go
+++ b/interpreter/nodev8/v8.go
@@ -226,7 +226,7 @@ const (
 
 var (
 	// regex for the interpreter executable
-	v8Regex = regexp.MustCompile(`^(?:.*/)?node$`)
+	v8Regex = regexp.MustCompile(`^(?:.*/)?node(\d+)?$`)
 
 	// The FileID used for V8 stub frames
 	v8StubsFileID = libpf.NewFileID(0x578b, 0x1d)


### PR DESCRIPTION
The prefix list generation was not updated at all when an existing mapping is seen again. To avoid extra work, create a per-mapping uint32 which is shared via pointer to the mapping and all prefixes generated from it. This allows updating the generation for all of them with one assignment.

Reported-by: Nayef Ghattas <nayef.ghattas@datadoghq.com>