### PR TITLE
Switch to math/rand/v2

### DIFF
--- a/libpf/convenience.go
+++ b/libpf/convenience.go
@@ -9,7 +9,7 @@ package libpf
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"reflect"
 	"time"
@@ -60,7 +60,6 @@ func AddJitter(baseDuration time.Duration, jitter float64) time.Duration {
 		log.Errorf("Jitter (%f) out of range [0..1].", jitter)
 		return baseDuration
 	}
-	// nolint:gosec
 	return time.Duration((1 + jitter - 2*jitter*rand.Float64()) * float64(baseDuration))
 }
 

--- a/pacmask/pacmask_arm64.go
+++ b/pacmask/pacmask_arm64.go
@@ -9,7 +9,7 @@
 package pacmask
 
 import (
-	"math/rand"
+	"math/rand/v2"
 )
 
 // PACIA is an "intrinsic" for the A64 `pacia` instruction.
@@ -57,9 +57,7 @@ func GetPACMask() uint64 {
 		// The stack pointer on aarch64 needs to be aligned to 8 bytes at all
 		// times. The `<< 3` ensures that this is always the case for our fake
 		// pointers that will temporarily be placed as a fake stack pointer.
-		// nolint:gosec
 		probe := uint64(rand.Uint32() << 3)
-		// nolint:gosec
 		modifier := rand.Uint64()
 		probeWithPAC := PACIA(probe, modifier)
 		mask |= probeWithPAC & ^uint64(0xFFFF_FFFF)

--- a/processmanager/manager_test.go
+++ b/processmanager/manager_test.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"testing"
 	"time"
@@ -94,15 +94,11 @@ type dummyStackDeltaProvider struct{}
 // GetIntervalStructuresForFile fills in the expected data structure with semi random data.
 func (d *dummyStackDeltaProvider) GetIntervalStructuresForFile(_ host.FileID,
 	_ *pfelf.Reference, result *sdtypes.IntervalData) error {
-	// nolint:gosec
-	r := rand.New(rand.NewSource(42))
+	r := rand.New(rand.NewPCG(42, 42))
 	addr := 0x10
-	// nolint:gosec
-	for i := 0; i < r.Intn(42); i++ {
-		// nolint:gosec
-		addr += r.Intn(42 * 42)
-		// nolint:gosec
-		data := int32(8 * r.Intn(42))
+	for i := 0; i < r.IntN(42); i++ {
+		addr += r.IntN(42 * 42)
+		data := int32(8 * r.IntN(42))
 		result.Deltas.Add(sdtypes.StackDelta{
 			Address: uint64(addr),
 			Info:    sdtypes.UnwindInfo{Opcode: sdtypes.UnwindOpcodeBaseSP, Param: data},
@@ -373,13 +369,13 @@ func TestNewMapping(t *testing.T) {
 			{pid: 2, vaddr: 0x40000, bias: 0x2000},
 			{pid: 3, vaddr: 0x60000, bias: 0x3000},
 			{pid: 4, vaddr: 0x40000, bias: 0x4000}},
-			expectedStackDeltas: 28},
+			expectedStackDeltas: 36},
 		"duplicate load": {newMapping: []mappingArgs{
 			{pid: 123, vaddr: 0x0F000, bias: 0x1000},
 			{pid: 456, vaddr: 0x50000, bias: 0x4000},
 			{pid: 789, vaddr: 0x40000, bias: 0}},
 			duplicate:           true,
-			expectedStackDeltas: 21},
+			expectedStackDeltas: 27},
 	}
 
 	cacheDir, err := os.MkdirTemp("", "*_cacheDir")

--- a/testsupport/io.go
+++ b/testsupport/io.go
@@ -9,7 +9,7 @@ package testsupport
 import (
 	"bytes"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 )
 
@@ -20,7 +20,7 @@ func ValidateReadAtWrapperTransparency(
 	bufferSize := uint64(len(reference))
 
 	// Samples random slices to validate within the file.
-	r := rand.New(rand.NewSource(0)) // nolint:gosec
+	r := rand.New(rand.NewPCG(0, 0))
 	for i := uint(0); i < iterations; i++ {
 		// Intentionally allow slices that over-read the file to test this case.
 		length := r.Uint64() % bufferSize

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -1145,7 +1145,7 @@ func (t *Tracer) probabilisticProfile(interval time.Duration, threshold uint) {
 	enableSampling := false
 	var probProfilingStatus = probProfilingDisable
 
-	if rand.Intn(ProbabilisticThresholdMax) < int(threshold) {
+	if rand.UintN(ProbabilisticThresholdMax) < threshold {
 		enableSampling = true
 		probProfilingStatus = probProfilingEnable
 		log.Debugf("Start sampling for next interval (%v)", interval)


### PR DESCRIPTION
math/rand/v2 has several advatages over math/rand.
See https://go.dev/blog/randv2

This change also reduces suppressions of gosec.
